### PR TITLE
1.0.5.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,11 +1,11 @@
 [root]
 name = "kailua_workspace"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
- "kailua_check 1.0.4",
+ "kailua_check 1.0.5",
  "kailua_diag 1.0.4",
  "kailua_env 1.0.4",
- "kailua_syntax 1.0.4",
+ "kailua_syntax 1.0.5",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parse-generics-shim 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -107,29 +107,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "kailua"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "clap 2.24.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "kailua_check 1.0.4",
+ "kailua_check 1.0.5",
  "kailua_diag 1.0.4",
  "kailua_env 1.0.4",
- "kailua_langsvr 1.0.4",
- "kailua_syntax 1.0.4",
- "kailua_workspace 1.0.4",
+ "kailua_langsvr 1.0.5",
+ "kailua_syntax 1.0.5",
+ "kailua_workspace 1.0.5",
 ]
 
 [[package]]
 name = "kailua_check"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "clap 2.24.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "kailua_diag 1.0.4",
  "kailua_env 1.0.4",
- "kailua_syntax 1.0.4",
+ "kailua_syntax 1.0.5",
  "kailua_test 1.0.4",
- "kailua_types 1.0.4",
+ "kailua_types 1.0.5",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parse-generics-shim 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "take_mut 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -154,17 +154,17 @@ version = "1.0.4"
 
 [[package]]
 name = "kailua_langsvr"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "futures 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "kailua_check 1.0.4",
+ "kailua_check 1.0.5",
  "kailua_diag 1.0.4",
  "kailua_env 1.0.4",
- "kailua_langsvr_protocol 1.0.4",
- "kailua_syntax 1.0.4",
- "kailua_types 1.0.4",
- "kailua_workspace 1.0.4",
+ "kailua_langsvr_protocol 1.0.5",
+ "kailua_syntax 1.0.5",
+ "kailua_types 1.0.5",
+ "kailua_workspace 1.0.5",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "owning_ref 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "kailua_langsvr_protocol"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "serde 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -189,7 +189,7 @@ dependencies = [
 
 [[package]]
 name = "kailua_syntax"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "clap 2.24.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -216,14 +216,14 @@ dependencies = [
 
 [[package]]
 name = "kailua_types"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "atomic 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "kailua_diag 1.0.4",
  "kailua_env 1.0.4",
- "kailua_syntax 1.0.4",
+ "kailua_syntax 1.0.5",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parse-generics-shim 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,10 +8,10 @@ dependencies = [
  "kailua_syntax 1.0.4",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parse-generics-shim 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -38,7 +38,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -49,7 +49,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "clap"
-version = "2.23.3"
+version = "2.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -57,9 +57,9 @@ dependencies = [
  "bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "term_size 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-segmentation 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-segmentation 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "vec_map 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -69,11 +69,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "env_logger"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -87,16 +87,16 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "idna"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-bidi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-bidi 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-normalization 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -109,8 +109,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "kailua"
 version = "1.0.4"
 dependencies = [
- "clap 2.23.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.24.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "kailua_check 1.0.4",
  "kailua_diag 1.0.4",
  "kailua_env 1.0.4",
@@ -123,14 +123,14 @@ dependencies = [
 name = "kailua_check"
 version = "1.0.4"
 dependencies = [
- "clap 2.23.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.24.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "kailua_diag 1.0.4",
  "kailua_env 1.0.4",
  "kailua_syntax 1.0.4",
  "kailua_test 1.0.4",
  "kailua_types 1.0.4",
- "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parse-generics-shim 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "take_mut 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -141,7 +141,7 @@ version = "1.0.4"
 dependencies = [
  "kailua_env 1.0.4",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parse-generics-shim 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -165,14 +165,14 @@ dependencies = [
  "kailua_syntax 1.0.4",
  "kailua_types 1.0.4",
  "kailua_workspace 1.0.4",
- "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "owning_ref 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parse-generics-shim 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-timer 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -182,35 +182,35 @@ dependencies = [
 name = "kailua_langsvr_protocol"
 version = "1.0.4"
 dependencies = [
- "serde 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "kailua_syntax"
 version = "1.0.4"
 dependencies = [
- "clap 2.23.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.24.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "kailua_diag 1.0.4",
  "kailua_env 1.0.4",
  "kailua_test 1.0.4",
- "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parse-generics-shim 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "kailua_test"
 version = "1.0.4"
 dependencies = [
- "clap 2.23.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.24.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kailua_diag 1.0.4",
  "kailua_env 1.0.4",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -220,11 +220,11 @@ version = "1.0.4"
 dependencies = [
  "atomic 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "kailua_diag 1.0.4",
  "kailua_env 1.0.4",
  "kailua_syntax 1.0.4",
- "log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "parse-generics-shim 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "take_mut 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -247,12 +247,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.21"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "log"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -265,7 +265,7 @@ name = "memchr"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -275,10 +275,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "num_cpus"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -293,7 +293,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "owning_ref 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot_core 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "thread-id 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread-id 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -302,7 +302,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -323,24 +323,24 @@ name = "rand"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -354,12 +354,12 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.0"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde_derive"
-version = "1.0.0"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -378,13 +378,13 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -440,17 +440,17 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "thread-id"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -458,7 +458,7 @@ name = "thread_local"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "thread-id 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread-id 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -473,7 +473,7 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.2.5"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -486,7 +486,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -512,7 +512,7 @@ name = "url"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "idna 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "idna 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -524,6 +524,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "vec_map"
 version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "vec_map"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -557,34 +562,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum atomic 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "81e4fe666ae9dd4eea17160116a5f0d1e52f74504669bfc034e22850d6b7d406"
 "checksum atty 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d912da0db7fa85514874458ca3651fe2cddace8d0b0505571dbdcd41ab490159"
 "checksum bitflags 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1370e9fc2a6ae53aea8b7a5110edbd08836ed87c88736dfabccade1c2b44bff4"
-"checksum clap 2.23.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f57e9b63057a545ad2ecd773ea61e49422ed1b1d63d74d5da5ecaee55b3396cd"
+"checksum clap 2.24.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6b8f69e518f967224e628896b54e41ff6acfb4dcfefc5076325c36525dac900f"
 "checksum dtoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "80c8b71fd71146990a9742fc06dcbbde19161a267e0ad4e572c35162f4578c90"
-"checksum env_logger 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e3856f1697098606fc6cb97a93de88ca3f3bc35bb878c725920e6e82ecf05e83"
+"checksum env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b"
 "checksum futures 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "55f0008e13fc853f79ea8fc86e931486860d4c4c156cdffb59fa5f7fa833660a"
 "checksum futures-cpupool 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a283c84501e92cade5ea673a2a7ca44f71f209ccdd302a3e0896f50083d2c5ff"
-"checksum idna 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6ac85ec3f80c8e4e99d9325521337e14ec7555c458a14e377d189659a427f375"
+"checksum idna 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2233d4940b1f19f0418c158509cd7396b8d70a5db5705ce410914dc8fa603b37"
 "checksum itoa 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eb2f404fbc66fd9aac13e998248505e7ecb2ad8e44ab6388684c5fb11c6c251c"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"
-"checksum libc 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)" = "88ee81885f9f04bff991e306fea7c1c60a5f0f9e409e99f6b40e3311a3363135"
-"checksum log 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "5141eca02775a762cc6cd564d8d2c50f67c0ea3a372cbf1c51592b3e029e10ad"
+"checksum libc 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)" = "e7eb6b826bfc1fdea7935d46556250d1799b7fe2d9f7951071f4291710665e3e"
+"checksum log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "880f77541efa6e5cc74e76910c9884d9859683118839d6a1dc3b11e63512565b"
 "checksum matches 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "efd7622e3022e1a6eaa602c4cea8912254e5582c9c692e9167714182244801b1"
 "checksum memchr 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1dbccc0e46f1ea47b9f17e6d67c5a96bd27030519c519c9c91327e31275a47b4"
 "checksum num-traits 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "e1cbfa3781f3fe73dc05321bed52a06d2d491eaa764c52335cf4399f046ece99"
-"checksum num_cpus 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a18c392466409c50b87369414a2680c93e739aedeb498eb2bff7d7eb569744e2"
+"checksum num_cpus 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca313f1862c7ec3e0dfe8ace9fa91b1d9cb5c84ace3d00f5ec4216238e93c167"
 "checksum owning_ref 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9d52571ddcb42e9c900c901a18d8d67e393df723fcd51dd59c5b1a85d0acb6cc"
 "checksum parking_lot 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "fa12d706797d42551663426a45e2db2e0364bd1dbf6aeada87e89c5f981f43e9"
 "checksum parking_lot_core 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "56a19dcbb5d1e32b6cccb8a9aa1fc2a38418c8699652e735e2bf391a3dc0aa16"
 "checksum parse-generics-shim 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c4adf4245783dfc1565c6e9740b0946d839d83bb6acef63b204ad7afff78ec31"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "022e0636ec2519ddae48154b028864bdce4eaf7d35226ab8e65c611be97b189d"
-"checksum regex 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4278c17d0f6d62dfef0ab00028feb45bd7d2102843f80763474eeb1be8a10c01"
-"checksum regex-syntax 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9191b1f57603095f105d317e375d19b1c9c5c3185ea9633a99a6dcbed04457"
+"checksum regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1731164734096285ec2a5ec7fea5248ae2f5485b3feeb0115af4fda2183b2d1b"
+"checksum regex-syntax 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad890a5eef7953f55427c50575c680c42841653abd2b028b68cd223d157f62db"
 "checksum same-file 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d931a44fdaa43b8637009e7632a02adc4f2b2e0733c08caa4cf00e8da4a117a7"
-"checksum serde 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "369633cfe0f0bde1dfc037fb6c5a329d46586a31f981bed14d87487a3439ae37"
-"checksum serde_derive 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6a61ecb8511aaff381424f98b49a059017420ec60e15e8d63b645701af7fa9b8"
+"checksum serde 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c0c3d79316a6051231925504f6ef893d45088e8823c77a8331a3dcf427ee9087"
+"checksum serde_derive 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "0019cd5b9f0529a1a0e145a912e9a2d60c325c58f7f260fc36c71976e9d76aee"
 "checksum serde_derive_internals 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "021c338d22c7e30f957a6ab7e388cb6098499dda9fd4ba1661ee074ca7a180d1"
-"checksum serde_json 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e9b1ec939469a124b27e208106550c38358ed4334d2b1b5b3825bc1ee37d946a"
+"checksum serde_json 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "48b04779552e92037212c3615370f6bd57a40ebba7f20e554ff9f55e41a69a7b"
 "checksum slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17b4fcaed89ab08ef143da37bc52adbcc04d4a69014f4c1208d6b51f0c47bc23"
 "checksum smallvec 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4f8266519bc1d17d0b5b16f6c21295625d562841c708f6376f49028a43e9c11e"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
@@ -593,18 +598,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum take_mut 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7986ceb18a0d75e1fcb8b27c0119389bbe05f016e5a6e54d003251acc1122108"
 "checksum term 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d168af3930b369cfe245132550579d47dfd873d69470755a19c2c6568dbbd989"
 "checksum term_size 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2b6b55df3198cc93372e85dd2ed817f0e38ce8cc0f22eb32391bfad9c4bf209"
-"checksum thread-id 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4437c97558c70d129e40629a5b385b3fb1ffac301e63941335e4d354081ec14a"
+"checksum thread-id 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8df7875b676fddfadffd96deea3b1124e5ede707d4884248931077518cf1f773"
 "checksum thread_local 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c85048c6260d17cf486ceae3282d9fb6b90be220bf5b28c400f5485ffc29f0c7"
 "checksum tokio-timer 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "86f33def658c14724fc13ec6289b3875a8152ee8ae767a5b1ccbded363b03db8"
-"checksum unicode-bidi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d3a078ebdd62c0e71a709c3d53d2af693fe09fe93fbff8344aebe289b78f9032"
+"checksum unicode-bidi 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c44d4e7ce691e2538b886bf33669fd6da1653a12d741b9390f351955c0949c03"
 "checksum unicode-normalization 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e28fa37426fceeb5cf8f41ee273faa7c82c47dc8fba5853402841e665fcd86ff"
-"checksum unicode-segmentation 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "18127285758f0e2c6cf325bb3f3d138a12fee27de4f23e146cd6a179f26c2cf3"
+"checksum unicode-segmentation 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a8083c594e02b8ae1654ae26f0ade5158b119bd88ad0e8227a5d8fcd72407946"
 "checksum unicode-width 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bf3a113775714a22dcb774d8ea3655c53a32debae63a063acc00a91cc586245f"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum unreachable 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1f2ae5ddb18e1c92664717616dd9549dde73f539f01bd7b77c2edb2446bdff91"
 "checksum url 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f5ba8a749fb4479b043733416c244fa9d1d3af3d7c23804944651c8a448cb87e"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum vec_map 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8cdc8b93bd0198ed872357fb2e667f7125646b1762f16d60b2c96350d361897"
+"checksum vec_map 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "887b5b631c2ad01628bbbaa7dd4c869f80d3186688f8d0b6f58774fbe324988c"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum walkdir 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "bb08f9e670fab86099470b97cd2b252d6527f0b3cc1401acdb595ffc9dd288ff"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kailua"
-version = "1.0.4"
+version = "1.0.5"
 authors = ["Nexon Corporation", "Kang Seonghoon <public+git@mearie.org>"]
 
 description = "🌴 Type Checker and IDE Support for Lua"
@@ -20,10 +20,10 @@ env_logger = "0.4.2"
 clap = "2"
 kailua_env = { version = "1.0.4", path = "kailua_env" }
 kailua_diag = { version = "1.0.4", path = "kailua_diag" }
-kailua_syntax = { version = "1.0.4", path = "kailua_syntax" }
-kailua_check = { version = "1.0.4", path = "kailua_check" }
-kailua_workspace = { version = "1.0.4", path = "kailua_workspace" }
-kailua_langsvr = { version = "1.0.4", path = "kailua_langsvr" }
+kailua_syntax = { version = "1.0.5", path = "kailua_syntax" }
+kailua_check = { version = "1.0.5", path = "kailua_check" }
+kailua_workspace = { version = "1.0.5", path = "kailua_workspace" }
+kailua_langsvr = { version = "1.0.5", path = "kailua_langsvr" }
 
 [workspace]
 members = [

--- a/kailua_check/Cargo.toml
+++ b/kailua_check/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kailua_check"
-version = "1.0.4"
+version = "1.0.5"
 authors = ["Nexon Corporation", "Kang Seonghoon <public+git@mearie.org>"]
 
 description = "Type checker for Kailua"
@@ -32,8 +32,8 @@ take_mut = "0.1"
 parse-generics-shim = "0.1.0"
 kailua_env = { version = "1.0.4", path = "../kailua_env" }
 kailua_diag = { version = "1.0.4", path = "../kailua_diag" }
-kailua_syntax = { version = "1.0.4", path = "../kailua_syntax" }
-kailua_types = { version = "1.0.4", path = "../kailua_types" }
+kailua_syntax = { version = "1.0.5", path = "../kailua_syntax" }
+kailua_types = { version = "1.0.5", path = "../kailua_types" }
 
 [dev-dependencies]
 clap = "2"

--- a/kailua_check/src/env.rs
+++ b/kailua_check/src/env.rs
@@ -386,7 +386,7 @@ impl<R: Report> Context<R> {
         &self.report
     }
 
-    pub fn open_library(&mut self, name: &Spanned<Name>, opts: Rc<RefCell<Options>>) -> Result<()> {
+    pub fn open_library(&mut self, name: Spanned<&[u8]>, opts: Rc<RefCell<Options>>) -> Result<()> {
         if let Some(defs) = str::from_utf8(&name.base).ok().and_then(get_defs) {
             // one library may consist of multiple files, so we defer duplicate check
             for def in defs {

--- a/kailua_langsvr/Cargo.toml
+++ b/kailua_langsvr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kailua_langsvr"
-version = "1.0.4"
+version = "1.0.5"
 authors = ["Nexon Corporation", "Kang Seonghoon <public+git@mearie.org>"]
 
 description = "Language server implementation for Kailua"
@@ -27,9 +27,9 @@ walkdir = "1"
 parse-generics-shim = "0.1.0"
 kailua_env = { version = "1.0.4", path = "../kailua_env" }
 kailua_diag = { version = "1.0.4", path = "../kailua_diag" }
-kailua_syntax = { version = "1.0.4", path = "../kailua_syntax" }
-kailua_types = { version = "1.0.4", path = "../kailua_types" }
-kailua_check = { version = "1.0.4", path = "../kailua_check" }
-kailua_workspace = { version = "1.0.4", path = "../kailua_workspace" }
-kailua_langsvr_protocol = { version = "1.0.4", path = "../kailua_langsvr_protocol" }
+kailua_syntax = { version = "1.0.5", path = "../kailua_syntax" }
+kailua_types = { version = "1.0.5", path = "../kailua_types" }
+kailua_check = { version = "1.0.5", path = "../kailua_check" }
+kailua_workspace = { version = "1.0.5", path = "../kailua_workspace" }
+kailua_langsvr_protocol = { version = "1.0.5", path = "../kailua_langsvr_protocol" }
 

--- a/kailua_langsvr/src/ops/hover.rs
+++ b/kailua_langsvr/src/ops/hover.rs
@@ -1,5 +1,8 @@
 // hover help: wait for checker outputs and get the informations from given position
 
+use std::sync::Arc;
+use std::collections::HashSet;
+
 use kailua_env::{Pos, Source};
 use kailua_diag::{Localize, Localized};
 use kailua_types::ty::{TypeContext, Display};
@@ -8,36 +11,40 @@ use kailua_check::env::Output;
 use diags;
 use protocol::*;
 
-pub fn help<F>(output: &Output, pos: Pos, source: &Source, mut localize: F) -> Option<Hover>
+pub fn help<F>(outputs: &[Arc<Output>], pos: Pos, source: &Source, mut localize: F) -> Option<Hover>
     where F: for<'a> FnMut(&'a Localize) -> Localized<'a, Localize>
 {
-    // find all slot-associated spans that contains the pos...
-    let spans = output.spanned_slots().contains(pos);
-    // ...and pick the smallest one among them (there should be at most one such span).
-    let closest_slot = spans.min_by_key(|slot| slot.span.len());
+    // for multiple outputs, we deduplicate the identical types
+    let mut hover_range = None;
+    let mut contents = Vec::new();
+    let mut seen = HashSet::new();
 
-    // format the slot if available
-    if let Some(slot) = closest_slot {
-        // the resulting output should be colorized as if it's in `--:`.
-        // in order to use a single syntax, we use a sequence of random invisible
-        // characters to "trick" the colorizer.
-        const TYPE_PREFIX: &'static str =
-            "\u{200c}\u{200d}\u{200d}\u{200c}\u{2060}\u{200c}\u{200b}\u{200d}\
-             \u{200c}\u{200c}\u{200d}\u{200b}\u{2060}\u{200d}\u{2060}\u{2060}";
+    for output in outputs {
+        // find all slot-associated spans that contains the pos...
+        let spans = output.spanned_slots().contains(pos);
+        // ...and pick the smallest one among them (there should be at most one such span).
+        let closest_slot = spans.min_by_key(|slot| slot.span.len());
 
-        let range = diags::translate_span(slot.span, source).map(|(_, range)| range);
-        let types = output.types() as &TypeContext;
-        Some(Hover {
-            contents: vec![
-                MarkedString {
-                    language: format!("lua"),
-                    value: format!("{}{:0.1}", TYPE_PREFIX, localize(&slot.display(types))),
-                }
-            ],
-            range: range,
-        })
-    } else {
-        None
+        // format the slot if available
+        if let Some(slot) = closest_slot {
+            // the resulting output should be colorized as if it's in `--:`.
+            // in order to use a single syntax, we use a sequence of random invisible
+            // characters to "trick" the colorizer.
+            const TYPE_PREFIX: &'static str =
+                "\u{200c}\u{200d}\u{200d}\u{200c}\u{2060}\u{200c}\u{200b}\u{200d}\
+                 \u{200c}\u{200c}\u{200d}\u{200b}\u{2060}\u{200d}\u{2060}\u{2060}";
+
+            let range = diags::translate_span(slot.span, source).map(|(_, range)| range);
+            let types = output.types() as &TypeContext;
+            let value = format!("{}{:0.1}", TYPE_PREFIX, localize(&slot.display(types)));
+            if seen.insert(value.clone()) {
+                // XXX currently this can differ throughout the outputs
+                hover_range = Some(range);
+                contents.push(MarkedString { language: format!("lua"), value: value });
+            }
+        }
     }
+
+    hover_range.map(|range| Hover { contents: contents, range: range })
 }
 

--- a/kailua_langsvr/src/ops/mod.rs
+++ b/kailua_langsvr/src/ops/mod.rs
@@ -1,4 +1,4 @@
-use kailua_env::Span;
+use kailua_env::{Span, Pos};
 use kailua_syntax::lex::{Tok, NestedToken};
 use kailua_types::ty::Slot;
 use kailua_check::env::Output;
@@ -10,32 +10,14 @@ pub mod definition; // also contains rename
 
 // common routines
 
-#[derive(Clone, Debug)]
-enum PrefixExprSlot {
-    NotFound,
-    Found(usize /*the last non-comment token index for prefix expr*/, Slot),
-}
-
 fn last_non_comment(tokens: &[NestedToken]) -> Option<(usize, &NestedToken)> {
     tokens.iter().enumerate().rev().find(|&(_, tok)| {
         match tok.tok.base { Tok::Comment => false, _ => true }
     })
 }
 
-// get a slot for a prefix expression which is bounded by tokens[..idx], if possible.
-// may return None if the preceding tokens do not look like a prefix expression at all.
-fn get_prefix_expr_slot(tokens: &[NestedToken], idx: usize,
-                        output: &Output) -> Option<PrefixExprSlot> {
-    // note that this approach of using the closest non-comment token's end is
-    // prone to syntax error; while completing `f"":` should work,
-    // `"":` (invalid, should have been `(""):`) will also work.
-    // as such a mistake can be readily reported, however, we don't try to perfect the approach.
-    let (end_idx, end) = if let Some((idx, tok)) = last_non_comment(&tokens[..idx]) {
-        (idx, tok.tok.span.end())
-    } else {
-        return None;
-    };
-
+// get a slot for a prefix expression which is bounded by (exclusive) end position, if possible.
+fn get_prefix_expr_slot(end: Pos, output: &Output) -> Option<Slot> {
     // find all slot-associated spans that intersects (even at the end points) the end pos...
     let spans = output.spanned_slots().adjacencies(Span::from(end));
     // ...and keep spans which actually _ends_ at the end pos...
@@ -43,10 +25,6 @@ fn get_prefix_expr_slot(tokens: &[NestedToken], idx: usize,
     // ...and pick the smallest one among them (there should be at most one such span).
     let closest_slot = spans_before.min_by_key(|slot| slot.span.len());
 
-    if let Some(slot) = closest_slot {
-        Some(PrefixExprSlot::Found(end_idx, slot.base.clone()))
-    } else {
-        Some(PrefixExprSlot::NotFound)
-    }
+    closest_slot.map(|slot| slot.base.clone())
 }
 

--- a/kailua_langsvr_protocol/Cargo.toml
+++ b/kailua_langsvr_protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kailua_langsvr_protocol"
-version = "1.0.4"
+version = "1.0.5"
 authors = ["Nexon Corporation", "Kang Seonghoon <public+git@mearie.org>"]
 
 description = "Language server protocol types for Kailua"

--- a/kailua_langsvr_protocol/src/lib.rs
+++ b/kailua_langsvr_protocol/src/lib.rs
@@ -117,7 +117,7 @@ macro_rules! enum_number {
         }
         $($t:tt)*
     ) => (
-        #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+        #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
         $(#[$attrs])*
         pub enum $name {
             $($variant = $value,)*

--- a/kailua_syntax/Cargo.toml
+++ b/kailua_syntax/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kailua_syntax"
-version = "1.0.4"
+version = "1.0.5"
 authors = ["Nexon Corporation", "Kang Seonghoon <public+git@mearie.org>"]
 
 description = "AST and parser for Kailua"

--- a/kailua_syntax/src/lex/mod.rs
+++ b/kailua_syntax/src/lex/mod.rs
@@ -15,6 +15,8 @@ pub enum Tok {
     Error,
 
     /// A comment token. The parser should ignore this.
+    ///
+    /// The shebang line (the first line starting with `#`) is also considered as a comment.
     Comment,
 
     /// A punctuation.

--- a/kailua_syntax/src/tests/tests.lua
+++ b/kailua_syntax/src/tests/tests.lua
@@ -2328,3 +2328,29 @@ g()
 do아햏햏end --@< Error: Unexpected character
 --! [Do([])]
 
+--8<-- first-line-with-hash-1
+#!/usr/bin/env lua
+a = 42
+--! [Assign([`a`_], [42])]
+
+--8<-- first-line-with-hash-2
+####
+a = 42
+--! [Assign([`a`_], [42])]
+
+--8<-- first-line-with-hash-3
+#
+a = 42
+--! [Assign([`a`_], [42])]
+
+--8<-- first-line-with-hash-4
+##
+--&
+--! []
+
+--8<-- non-first-line-with-hash
+a = 42
+####
+b --@^-< Error: Only function calls are allowed as statement-level expressions
+--! [Assign([`a`_], [42]), Void((# (# (# (# `b`_)))))]
+

--- a/kailua_types/Cargo.toml
+++ b/kailua_types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kailua_types"
-version = "1.0.4"
+version = "1.0.5"
 authors = ["Nexon Corporation", "Kang Seonghoon <public+git@mearie.org>"]
 
 description = "Type system for Kailua"
@@ -22,5 +22,5 @@ atomic = "0.3"
 parking_lot = "0.3"
 kailua_env = { version = "1.0.4", path = "../kailua_env" }
 kailua_diag = { version = "1.0.4", path = "../kailua_diag" }
-kailua_syntax = { version = "1.0.4", path = "../kailua_syntax" }
+kailua_syntax = { version = "1.0.5", path = "../kailua_syntax" }
 

--- a/kailua_vsc/CHANGELOG.md
+++ b/kailua_vsc/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.0.5 (2017-06-01)
+
+* Multiple `start_path`s are accepted in `kailua.json`. They result in multiple separate checking contexts, possibly diverging to each other (in which case all possible types and signatures are displayed in the editor). The reports are deduplicated as much as possible, so shared codes should have the identical reports for most cases.
+
+* The `preload` object has been added to `kailua.json`. It can be used to populate the execution environment before checking: a value of `{"open": ["lua51"], "require": ["A", "B"]}` will, for example, execute `--# open lua51`, `require "A"` and `require "B"` in the order. (`Require`s will be affected by `package_path` and so on.)
+
+* Skips the first line as a comment if it starts with `#`, i.e. looks like a shebang line like `#!/usr/bin/lua`. (#10)
+
+* Improved the usage of the extension on non-Windows by trying global `kailua` executables.
+
 ## 1.0.4 (2017-04-25)
 
 The first public, free and open-source version of Kailua.

--- a/kailua_vsc/README.md
+++ b/kailua_vsc/README.md
@@ -7,6 +7,7 @@ checklist:
 * remove "Standalone Checker" section and rename "Installation and Usage" to "Usage"
 * remove "Source Organization" section
 * convert all images into the data URIs
+* reword the non-Windows indications to refer to the repository
 -->
 
 [한국어](https://github.com/devcat-studio/kailua/tree/master/README.ko.md)
@@ -17,9 +18,7 @@ checklist:
 
 ## Usage
 
-**Caution: Currently the extension only works in Windows due to the packaging issue.**
-
-Kailua can be used as an IDE support for [Visual Studio Code][VSCode]. Install Kailua by typing `ext install kailua` from the Quick Launch (`Ctrl-P`).
+Kailua can be used as an IDE support for [Visual Studio Code][VSCode]. Install Kailua by typing `ext install kailua` from the Quick Launch (`Ctrl-P`). **If you are not on Windows, you should also install the [standalone checker](https://github.com/devcat-studio/kailua/#standalone-checker) first.**
 
 You will see a warning that the configuration file is missing when you open a folder containing Lua codes. You need it for real-time checking.
 
@@ -167,22 +166,20 @@ The following content is required for `.vscode/kailua.json`, in case you are edi
 
 ```json5
 {
-    // Unlike a normal JSON, a comment or a stray comma is allowed.
     "start_path": "<path to the entry point>",
 
-    // You can also put the following:
-    //
-    //"package_path": "<the value of `package.path`, determined from assignments if missing>",
-    //"package_cpath": "<the value of `package.cpath`, determined from assignments if missing>",
+    "preload": {
+        // This indicates that we are using Lua 5.1 and all built-in libraries of it.
+        "open": ["lua51"],
+    },
 }
 ```
 
 You need to reload the current window (`Ctrl-R` or `Cmd-R`) to apply the configuration.
 
-Once you've set the entry point, you can write your first Kailua code:
+Once you've set the entry point, you can write your first Kailua code (simple, eh?):
 
 ```lua
---# open lua51
 print('Hello, world!')
 ```
 
@@ -317,6 +314,42 @@ As annotating everything is not practical, Kailua supports two ways to avoid the
   When `require()` was used with a check-time string Kailua makes use of `package.path` and `package.cpath` set. For `package.path`, it will try `F.kailua` first before reading a file `F`. For `package.cpath`, it will always `F.kailua` as `F` would be probably binary. (Note that this will normally result in two extensions `.lua.kailua` unless you have a sole `?` in the search paths.)
 
   `.kailua` files would frequently use `--# assume` as you should *assume* that the original code has given types.
+
+## Configuration Format
+
+You can configure the exact behavior of Kailua with `kailua.json`. It is a JSON with comments (`//`) and stray comma allowed for convenience:
+
+```json5
+{
+    // This indicates where to start. This is the only mandatory field in the file.
+    //
+    // This can be a single string or an array of strings, and in the latter case
+    // multiple paths are separately (but possibly parallelly) checked against.
+    // Checking sessions do not affect others, but reports are merged.
+    "start_path": ["entrypoint.lua", "lib/my_awesome_lib.lua"],
+
+    // These are values for `package.path` and `package.cpath` variables, respectively.
+    // Refer to the Lua manual for the exact format.
+    //
+    // If they are not explicitly set, they are inferred from any assignments to
+    // `package.path` and `package.cpath` variables. This can be handy for scripts,
+    // but will be cumbersome for most other cases.
+    //
+    // It should be also noted that any path in `package_cpath` won't be directly
+    // read by Kailua; only `.kailua` files associated to them will be read.
+    "package_path": "?.lua;contrib/?.lua",
+    "package_cpath": "native/?",
+
+    // The preloading options to populate the environment before checking.
+    // They are executed in the following order, and in each array, in given order.
+    "preload": {
+        // A list of `--# open` arguments.
+        "open": ["lua51"],
+        // A list of `require()` arguments. Affected by `package_*` options.
+        "require": ["depA", "depB.core"],
+    },
+}
+```
 
 <!-- -->
 

--- a/kailua_vsc/kailua.schema.json
+++ b/kailua_vsc/kailua.schema.json
@@ -3,8 +3,18 @@
     "type": "object",
     "properties": {
         "start_path": {
-            "type": "string",
-            "description": "Specifies the path of the source file to begin the checking. The path is relative to the workspace directory."
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            ],
+            "description": "Specifies the path(s) of the source file to begin the checking. The path is relative to the workspace directory. Multiple paths are allowed and individually checked."
         },
         "package_path": {
             "type": "string",

--- a/kailua_vsc/kailua.schema.json
+++ b/kailua_vsc/kailua.schema.json
@@ -14,15 +14,35 @@
                     }
                 }
             ],
-            "description": "Specifies the path(s) of the source file to begin the checking. The path is relative to the workspace directory. Multiple paths are allowed and individually checked."
+            "description": "Path(s) of the source file to begin the checking. The path is relative to the workspace directory. Multiple paths are allowed and individually checked."
         },
         "package_path": {
             "type": "string",
-            "description": "Specifies the value of `package.path`. The paths are relative to the workspace directory. `package.path` can be dynamically set in the program, but such assignments will be ignored if the explicit value is given here."
+            "description": "A value of `package.path`. The paths are relative to the workspace directory. `package.path` can be dynamically set in the program, but such assignments will be ignored if the explicit value is given here."
         },
         "package_cpath": {
             "type": "string",
-            "description": "Specifies the value of `package.cpath`. The paths are relative to the workspace directory. `package.cpath` can be dynamically set in the program, but such assignments will be ignored if the explicit value is given here."
+            "description": "A value of `package.cpath`. The paths are relative to the workspace directory. `package.cpath` can be dynamically set in the program, but such assignments will be ignored if the explicit value is given here."
+        },
+        "preload": {
+            "type": "object",
+            "properties": {
+                "open": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "A list of built-in libraries loaded as like `--# open`. Takes precedence over `require`."
+                },
+                "require": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "A list of libraries loaded via `require()`."
+                }
+            },
+            "description": "A list of default libraries that will be preloaded into the environment before checking."
         }
     },
     "required": ["start_path"]

--- a/kailua_vsc/package.json
+++ b/kailua_vsc/package.json
@@ -2,7 +2,7 @@
   "name": "kailua",
   "displayName": "Kailua",
   "description": "A type checker and IDE support for Lua",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "publisher": "devCAT",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/devcat-studio/kailua",

--- a/kailua_vsc/syntaxes/kailua.json
+++ b/kailua_vsc/syntaxes/kailua.json
@@ -70,6 +70,15 @@
 			"include": "#string-multiline"
 		},
 		{
+			"captures": {
+				"1": {
+					"name": "punctuation.definition.comment.lua"
+				}
+			},
+			"match": "\\A(#!).*$\\n?",
+			"name": "comment.line.shebang.lua"
+		},
+		{
 			"include": "#comment-block"
 		},
 		{

--- a/kailua_workspace/Cargo.toml
+++ b/kailua_workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kailua_workspace"
-version = "1.0.4"
+version = "1.0.5"
 authors = ["Nexon Corporation", "Kang Seonghoon <public+git@mearie.org>"]
 
 description = "Workspace support for Kailua"
@@ -20,6 +20,6 @@ lazy_static = "0.2"
 parse-generics-shim = "0.1.0"
 kailua_env = { version = "1.0.4", path = "../kailua_env" }
 kailua_diag = { version = "1.0.4", path = "../kailua_diag" }
-kailua_syntax = { version = "1.0.4", path = "../kailua_syntax" }
-kailua_check = { version = "1.0.4", path = "../kailua_check" }
+kailua_syntax = { version = "1.0.5", path = "../kailua_syntax" }
+kailua_check = { version = "1.0.5", path = "../kailua_check" }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ fn parse_and_check(workspace: &Workspace, quiet: bool) -> Result<(), String> {
     use kailua_diag::message::{Locale, Localize};
     use kailua_diag::report::{Stop, Kind, Report, ConsoleReport, TrackMaxKind};
     use kailua_syntax::{parse_chunk, Chunk};
-    use kailua_check::check_from_chunk;
+    use kailua_check::check_from_chunk_with_preloading;
     use kailua_check::env::Context;
     use kailua_check::options::FsSource;
     use kailua_workspace::WorkspaceOptions;
@@ -101,7 +101,9 @@ fn parse_and_check(workspace: &Workspace, quiet: bool) -> Result<(), String> {
 
         let opts = Rc::new(RefCell::new(WorkspaceOptions::new(fssource, workspace)));
 
-        if !(check_from_chunk(&mut context, filechunk, opts).is_ok() && report.can_continue()) {
+        let output = check_from_chunk_with_preloading(&mut context, filechunk, opts,
+                                                      workspace.preload());
+        if !(output.is_ok() && report.can_continue()) {
             return Err(format!("Stopped due to prior errors"));
         }
     }


### PR DESCRIPTION
* Multiple `start_path`s are accepted in `kailua.json`. They result in multiple separate checking contexts, possibly diverging to each other (in which case all possible types and signatures are displayed in the editor). The reports are deduplicated as much as possible, so shared codes should have the identical reports for most cases.

* The `preload` object has been added to `kailua.json`. It can be used to populate the execution environment before checking: a value of `{"open": ["lua51"], "require": ["A", "B"]}` will, for example, execute `--# open lua51`, `require "A"` and `require "B"` in the order. (`Require`s will be affected by `package_path` and so on.)

* Skips the first line as a comment if it starts with `#`, i.e. looks like a shebang line like `#!/usr/bin/lua`.

* Improved the usage of the extension on non-Windows by trying global `kailua` executables. 

Fixes #10.
Considerably improves #1. (The documentation has been altered to reflect this fact.)