### PR TITLE
1.0.6.

### DIFF
--- a/kailua_vsc/CHANGELOG.md
+++ b/kailua_vsc/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.6 (2017-06-02)
+
+* Fixed the environment used for the global `kailua` executable. The bug had caused that the executable installed by the normal method (`cargo install -f kailua`) is unavailable to the extension for many cases due to the lack of the user-local `$PATH` environment variable.
+
 ## 1.0.5 (2017-06-01)
 
 * Multiple `start_path`s are accepted in `kailua.json`. They result in multiple separate checking contexts, possibly diverging to each other (in which case all possible types and signatures are displayed in the editor). The reports are deduplicated as much as possible, so shared codes should have the identical reports for most cases.

--- a/kailua_vsc/package.json
+++ b/kailua_vsc/package.json
@@ -2,7 +2,7 @@
   "name": "kailua",
   "displayName": "Kailua",
   "description": "A type checker and IDE support for Lua",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "publisher": "devCAT",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/devcat-studio/kailua",

--- a/kailua_vsc/src/extension.ts
+++ b/kailua_vsc/src/extension.ts
@@ -111,6 +111,7 @@ function initializeLanguageServer(context: vscode.ExtensionContext) {
             }
             languageClient.outputChannel.append(`spawning a language server (${mode})\n`);
 
+            env = Object.assign({}, process.env, env);
             const cp = spawn(executablePath, args, {env: env});
             cp.on('error', e => {
                 languageClient.outputChannel.append(`failed to spawn a language server: ${e}\n`);


### PR DESCRIPTION
A minor release to fix a critical issue that hasn't been caught in 1.0.5 (ugh).

* Fixed the environment used for the global `kailua` executable. The bug had caused that the executable installed by the normal method (`cargo install -f kailua`) is unavailable to the extension for many cases due to the lack of the user-local `$PATH` environment variable.