### PR TITLE
1.0.7.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,6 +1,6 @@
 [root]
 name = "kailua_workspace"
-version = "1.0.5"
+version = "1.0.7"
 dependencies = [
  "kailua_check 1.0.5",
  "kailua_diag 1.0.4",
@@ -107,16 +107,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "kailua"
-version = "1.0.5"
+version = "1.0.7"
 dependencies = [
  "clap 2.24.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "kailua_check 1.0.5",
  "kailua_diag 1.0.4",
  "kailua_env 1.0.4",
- "kailua_langsvr 1.0.5",
+ "kailua_langsvr 1.0.7",
  "kailua_syntax 1.0.5",
- "kailua_workspace 1.0.5",
+ "kailua_workspace 1.0.7",
 ]
 
 [[package]]
@@ -154,7 +154,7 @@ version = "1.0.4"
 
 [[package]]
 name = "kailua_langsvr"
-version = "1.0.5"
+version = "1.0.7"
 dependencies = [
  "futures 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -164,7 +164,7 @@ dependencies = [
  "kailua_langsvr_protocol 1.0.5",
  "kailua_syntax 1.0.5",
  "kailua_types 1.0.5",
- "kailua_workspace 1.0.5",
+ "kailua_workspace 1.0.7",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "owning_ref 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kailua"
-version = "1.0.5"
+version = "1.0.7"
 authors = ["Nexon Corporation", "Kang Seonghoon <public+git@mearie.org>"]
 
 description = "🌴 Type Checker and IDE Support for Lua"
@@ -22,8 +22,8 @@ kailua_env = { version = "1.0.4", path = "kailua_env" }
 kailua_diag = { version = "1.0.4", path = "kailua_diag" }
 kailua_syntax = { version = "1.0.5", path = "kailua_syntax" }
 kailua_check = { version = "1.0.5", path = "kailua_check" }
-kailua_workspace = { version = "1.0.5", path = "kailua_workspace" }
-kailua_langsvr = { version = "1.0.5", path = "kailua_langsvr" }
+kailua_workspace = { version = "1.0.7", path = "kailua_workspace" }
+kailua_langsvr = { version = "1.0.7", path = "kailua_langsvr" }
 
 [workspace]
 members = [

--- a/README.ko.md
+++ b/README.ko.md
@@ -216,7 +216,14 @@ print('Hello, world!')
     "start_path": ["entrypoint.lua", "lib/my_awesome_lib.lua"],
 
     // `package.path`와 `package.cpath` 변수의 값을 나타냅니다.
+    // 이 경로는 항상 기준 디렉토리(`.vscode`나 `kailua.json`을 담는 디렉토리)에 상대적입니다.
     // 정확한 포맷은 루아 설명서를 참고하세요.
+    //
+    // 설정 파일에서는 `{start_dir}` 문자열을 쓰면 *현재* 시작 경로를 담은 디렉토리로
+    // 치환됩니다. 따라서 만약 시작 경로가 `foo/a.lua`와 `bar/b.lua` 두 개라면,
+    // `{start_dir}/?.lua`는 각 시작 경로에 대해 `foo/?.lua`와 `bar/?.lua`로 확장됩니다.
+    // 이 기능은 여러 프로젝트를 각자의 디렉토리에 넣고 일부 공통되는 파일만
+    // 공유하고 싶을 때 유용합니다.
     //
     // 만약 여기서 명시적으로 설정되지 않았을 경우, 이들 설정은 `package.path`와
     // `package.cpath`에 설정되는 값으로부터 추론됩니다. 이 동작은 스크립트에서는

--- a/README.md
+++ b/README.md
@@ -216,7 +216,16 @@ You can configure the exact behavior of Kailua with `kailua.json`. It is a JSON 
     "start_path": ["entrypoint.lua", "lib/my_awesome_lib.lua"],
 
     // These are values for `package.path` and `package.cpath` variables, respectively.
+    // They are always relative to the base directory
+    // (a directory containing `.vscode` or `kailua.json` whichever being used).
     // Refer to the Lua manual for the exact format.
+    //
+    // In the configuration one can use a special `{start_dir}` sequence
+    // which gets replaced by the directory containing the *current* start path.
+    // so if there are two start paths `foo/a.lua` and `bar/b.lua`,
+    // the path of `{start_dir}/?.lua` will expand to `foo/?.lua` or `bar/?.lua`
+    // for each start path. This is useful when you are working with multiple projects
+    // with individual directories, only sharing a portion of common codes.
     //
     // If they are not explicitly set, they are inferred from any assignments to
     // `package.path` and `package.cpath` variables. This can be handy for scripts,

--- a/kailua_langsvr/Cargo.toml
+++ b/kailua_langsvr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kailua_langsvr"
-version = "1.0.5"
+version = "1.0.7"
 authors = ["Nexon Corporation", "Kang Seonghoon <public+git@mearie.org>"]
 
 description = "Language server implementation for Kailua"
@@ -30,6 +30,6 @@ kailua_diag = { version = "1.0.4", path = "../kailua_diag" }
 kailua_syntax = { version = "1.0.5", path = "../kailua_syntax" }
 kailua_types = { version = "1.0.5", path = "../kailua_types" }
 kailua_check = { version = "1.0.5", path = "../kailua_check" }
-kailua_workspace = { version = "1.0.5", path = "../kailua_workspace" }
+kailua_workspace = { version = "1.0.7", path = "../kailua_workspace" }
 kailua_langsvr_protocol = { version = "1.0.5", path = "../kailua_langsvr_protocol" }
 

--- a/kailua_langsvr/src/lib.rs
+++ b/kailua_langsvr/src/lib.rs
@@ -900,6 +900,9 @@ pub enum Target {
 pub fn main(target: Target) -> io::Result<()> {
     use std::net::TcpStream;
 
+    info!("starting kailua_langsvr {}",
+          option_env!("CARGO_PKG_VERSION").unwrap_or("unknown version"));
+
     let server = match target {
         Target::Stdio => Server::from_stdio(),
         Target::TCP(addr) => {

--- a/kailua_langsvr/src/workspace.rs
+++ b/kailua_langsvr/src/workspace.rs
@@ -815,6 +815,7 @@ impl Workspace {
     ) -> ReportFuture<Arc<Output>> {
         let start_chunk_fut = self.ensure_file(start_path).ensure_chunk();
 
+        let start_path = start_path.to_owned();
         let files = self.files.clone();
         let source = self.source.clone();
         let cancel_token = shared.cancel_token.clone();
@@ -851,8 +852,8 @@ impl Workspace {
                     return Err(From::from(diags));
                 },
                 WorkspaceBase::Workspace(ref ws) => {
-                    (Rc::new(RefCell::new(WorkspaceOptions::new(fssource.clone(), ws))),
-                     ws.preload().clone())
+                    let opts = WorkspaceOptions::new(fssource.clone(), &start_path, ws);
+                    (Rc::new(RefCell::new(opts)), ws.preload().clone())
                 },
             };
 

--- a/kailua_vsc/CHANGELOG.md
+++ b/kailua_vsc/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.7 (2017-06-02)
+
+* `package_[c]path` configuration values now support a special syntax for specifying paths relative to the start path, not the base dir. (See the manual for the exact format.) This is useful when you are working with multiple projects with individual directories, only sharing a portion of common codes.
+
 ## 1.0.6 (2017-06-02)
 
 * Fixed the environment used for the global `kailua` executable. The bug had caused that the executable installed by the normal method (`cargo install -f kailua`) is unavailable to the extension for many cases due to the lack of the user-local `$PATH` environment variable.

--- a/kailua_vsc/README.md
+++ b/kailua_vsc/README.md
@@ -329,7 +329,16 @@ You can configure the exact behavior of Kailua with `kailua.json`. It is a JSON 
     "start_path": ["entrypoint.lua", "lib/my_awesome_lib.lua"],
 
     // These are values for `package.path` and `package.cpath` variables, respectively.
+    // They are always relative to the base directory
+    // (a directory containing `.vscode` or `kailua.json` whichever being used).
     // Refer to the Lua manual for the exact format.
+    //
+    // In the configuration one can use a special `{start_dir}` sequence
+    // which gets replaced by the directory containing the *current* start path.
+    // so if there are two start paths `foo/a.lua` and `bar/b.lua`,
+    // the path of `{start_dir}/?.lua` will expand to `foo/?.lua` or `bar/?.lua`
+    // for each start path. This is useful when you are working with multiple projects
+    // with individual directories, only sharing a portion of common codes.
     //
     // If they are not explicitly set, they are inferred from any assignments to
     // `package.path` and `package.cpath` variables. This can be handy for scripts,

--- a/kailua_vsc/package.json
+++ b/kailua_vsc/package.json
@@ -2,7 +2,7 @@
   "name": "kailua",
   "displayName": "Kailua",
   "description": "A type checker and IDE support for Lua",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "publisher": "devCAT",
   "license": "(MIT OR Apache-2.0)",
   "homepage": "https://github.com/devcat-studio/kailua",

--- a/kailua_workspace/Cargo.toml
+++ b/kailua_workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kailua_workspace"
-version = "1.0.5"
+version = "1.0.7"
 authors = ["Nexon Corporation", "Kang Seonghoon <public+git@mearie.org>"]
 
 description = "Workspace support for Kailua"

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,7 +99,7 @@ fn parse_and_check(workspace: &Workspace, quiet: bool) -> Result<(), String> {
             return Err(format!("Stopped due to prior errors"));
         }
 
-        let opts = Rc::new(RefCell::new(WorkspaceOptions::new(fssource, workspace)));
+        let opts = Rc::new(RefCell::new(WorkspaceOptions::new(fssource, start_path, workspace)));
 
         let output = check_from_chunk_with_preloading(&mut context, filechunk, opts,
                                                       workspace.preload());
@@ -239,8 +239,10 @@ pub fn main() {
             }
         };
 
-        config.package_path = parse_package_paths("set_package_path", "add_package_path");
-        config.package_cpath = parse_package_paths("set_package_cpath", "add_package_cpath");
+        config.package_path =
+            parse_package_paths("set_package_path", "add_package_path").or(config.package_path);
+        config.package_cpath =
+            parse_package_paths("set_package_cpath", "add_package_cpath").or(config.package_cpath);
 
         let quiet = matches.is_present("quiet");
 


### PR DESCRIPTION
- `package_[c]path` configuration values now support a special syntax for specifying paths relative to the start path, not the base dir. This is useful when you are working with multiple projects with individual directories, only sharing a portion of common codes.

- The CLI accidentally used to ignore the configuration file's `package_[c]path` values no matter they are overriden from arguments or not.